### PR TITLE
Fix jitter on arrival

### DIFF
--- a/src/player/character.js
+++ b/src/player/character.js
@@ -75,7 +75,8 @@ export function updateCharacter(delta) {
 
   if (dist > 0.1) {
     dir.normalize();
-    character.position.addScaledVector(dir, speed * delta);
+    const step = Math.min(speed * delta, dist);
+    character.position.addScaledVector(dir, step);
     // orientation
     const q = new THREE.Quaternion().setFromUnitVectors(
       new THREE.Vector3(0, 0, 1),


### PR DESCRIPTION
## Summary
- clamp the step size so character doesn't overshoot destination

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852a672a1e08321b8ea4197f70244f2