### PR TITLE
Add GLTF model loader utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Sync version : 0.0.2
+
+## 3D Models
+You can find free `.glb` assets such as trees on sites like [Poly Haven](https://polyhaven.com/models) or [Sketchfab](https://sketchfab.com). Once downloaded, place the model in your assets folder and load it using `loadModel()` from `src/world/modelLoader.js`.

--- a/src/world/modelLoader.js
+++ b/src/world/modelLoader.js
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { scene } from './scene.js';
+
+const loader = new GLTFLoader();
+
+export function loadModel(url, position = new THREE.Vector3()) {
+  return new Promise((resolve) => {
+    loader.load(
+      url,
+      (gltf) => {
+        const model = gltf.scene;
+        model.position.copy(position);
+        scene.add(model);
+        resolve(model);
+      },
+      undefined,
+      (err) => {
+        console.error(`Failed to load model: ${url}`, err);
+        resolve(null);
+      }
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- install `three@0.176.0`
- add `modelLoader.js` with `GLTFLoader` helper
- document where to find example `.glb` assets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852ba4854248321b86553c49483e565